### PR TITLE
ci: pin pnpm to v10 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
         with:
+          version: 10
           run_install: false
 
       - name: Install Node.js


### PR DESCRIPTION
## Summary
- Pins `pnpm/action-setup` to `version: 10` in `.github/workflows/publish.yml`
- Fixes broken npm publish on tag (last two releases v4.2.4, v4.2.5 failed with `ENEEDAUTH`)

## Root cause
`pnpm/action-setup` v6.0.3+ began installing **pnpm v11.0.0-rc.5** as the global PATH shim. The `pnpm publish` step picked up the prerelease (instead of the `packageManager: pnpm@10.33.0` pinned in `package.json`), and that RC fails npm Trusted Publishing OIDC auth — npm sees no token and rejects with `ENEEDAUTH`.

Pinning `version: 10` keeps the global shim on stable pnpm v10 and restores the OIDC/`--provenance` flow that worked through v4.2.3.

## Evidence
- Last working run (v4.2.3, Apr 21) — published with `Done in 1.9s using pnpm v10.33.0` and `Provenance statement published to transparency log`
- First broken run (v4.2.4, Apr 30) — first run after `pnpm/action-setup` was bumped 6.0.1 → 6.0.3, install step shows `Done in 1.6s using pnpm v11.0.0-rc.5`, publish exits with `npm error code ENEEDAUTH`

## Test plan
- [ ] Merge, then push a patch tag (e.g. v4.2.6) and confirm the `Publish to NPM` job succeeds and the npm provenance statement is logged