### PR TITLE
ci: match pnpm version exactly to packageManager pin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
         with:
-          version: 10
+          version: 10.33.0
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Read pnpm version from packageManager
+        id: pnpm-version
+        run: echo "version=$(jq -r '.packageManager | split("@")[1]' package.json)" >> "$GITHUB_OUTPUT"
+
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
         with:
-          version: 10.33.0
+          version: ${{ steps.pnpm-version.outputs.version }}
           run_install: false
 
       - name: Install Node.js


### PR DESCRIPTION
## Summary
- Reads `.packageManager` from `package.json` at workflow runtime and passes the version to `pnpm/action-setup`'s `version:` input
- Single source of truth: bumping `packageManager` (which Dependabot already does) automatically propagates to CI

## Why this is needed
[pnpm/action-setup#227](https://github.com/pnpm/action-setup/issues/227): v6.0.3+ does not reliably install the `packageManager` version when `version:` is omitted — instead it falls back to the bootstrap pnpm (currently **v11.0.0-rc.5**), which fails npm Trusted Publishing OIDC auth (`ENEEDAUTH`). That's the original regression that broke v4.2.4 / v4.2.5 / v4.2.6.

But specifying a hardcoded `version:` (e.g. `10.33.0`) creates a second place to keep in sync with `packageManager`, and Dependabot's `github-actions` ecosystem only updates `uses:` SHAs — it can't bump arbitrary workflow inputs.

The dynamic extraction satisfies action-setup v6.0.5's strict `version-must-match-packageManager` validation while keeping `package.json` as the only place to update.

## Test plan
- [ ] Merge, push v4.2.7, confirm `Publish to NPM` succeeds and the provenance statement is logged
- [ ] Revert to omitting `version:` once pnpm/action-setup#227 is fixed