### PR TITLE
fix: adapt to js-yaml v5 named-export ESM API (broken release v4.2.14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: build types
-        run: pnpm run build:types
+      - name: Build
+        run: pnpm run build:all
 
       - name: Lint
         run: pnpm run lint

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^26.0.0",
     "esbuild": "^0.28.0",
     "jest": "^30.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.0
@@ -1007,9 +1004,6 @@ packages:
 
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/node@26.0.0':
     resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
@@ -3026,8 +3020,6 @@ snapshots:
     dependencies:
       expect: 30.3.0
       pretty-format: 30.3.0
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/node@26.0.0':
     dependencies:

--- a/src/readers/yaml.test.ts
+++ b/src/readers/yaml.test.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { YamlReader } from "./yaml";
 
 jest.mock("fs/promises");

--- a/src/readers/yaml.ts
+++ b/src/readers/yaml.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { DataReader, DataRow } from "./data-reader";
 
 export class YamlReader extends DataReader {


### PR DESCRIPTION
## Problem

The `js-yaml 4.2.0 → 5.0.0` bump (#190) was merged as a routine dependency PR, but it is a **breaking change**. js-yaml v5 is ESM-only and dropped its default export. This broke the **Publish to NPM** build for tag `v4.2.14`:

```
✘ [ERROR] No matching export in ".../js-yaml@5.0.0/.../js-yaml.mjs" for import "default"
    src/readers/yaml.ts:2:7:
      2 │ import yaml from "js-yaml";
```

The `v4.2.14` git tag/release exists, but **nothing was published to NPM**.

## Why CI didn't catch it

The PR test workflow only ran `build:types` (`tsc --emitDeclarationOnly`), **not** the esbuild bundle (`build`). On top of that, the stale `@types/js-yaml@4` still declared a default export, so type-checking passed. The breakage only surfaced at publish time via `prepublishOnly -> build:all`.

## Fix

- Use `import * as yaml from "js-yaml"` in `yaml.ts` and `yaml.test.ts` (`config.ts` and `templates/index.ts` already used the namespace form).
- Remove `@types/js-yaml` — v5 ships its own type declarations.
- **Run the full `build:all` in PR CI** instead of only `build:types`, so bundle-time export errors are caught before release.

## Verification

Locally, all PR steps pass: `build:all` OK · lint OK · fmt OK · `jest` 140/140 OK

## Follow-up

After merge, cut **v4.2.15** so a working build is published to NPM.